### PR TITLE
fix(AppBar): fix selected state label color in bottom navigation bar

### DIFF
--- a/appbars/README.md
+++ b/appbars/README.md
@@ -53,7 +53,7 @@ VitaminTopBars.Primary(
         ActionItem(
             icon = painterResource(R.drawable.ic_vtmn_android_line),
             contentDescription = null,
-            content = { Text("Android") },
+            text = { Text("Android") },
             onClick = { return@ActionItem true }
         ),
         ActionItem(
@@ -184,21 +184,21 @@ VitaminBottomNavigations.Primary(
             selected = true,
             icon = painterResource(R.drawable.ic_vtmn_android_line),
             contentDescription = null,
-            content = { Text("Android") },
+            content = "Android",
             onClick = { return@SelectedActionItem true }
         ),
         SelectedActionItem(
             selected = false,
             icon = painterResource(R.drawable.ic_vtmn_apple_line),
             contentDescription = null,
-            content = { Text("Apple") },
+            content = "Apple",
             onClick = { return@SelectedActionItem true }
         ),
         SelectedActionItem(
             selected = false,
             icon = painterResource(R.drawable.ic_vtmn_amazon_line),
             contentDescription = null,
-            content = { Text("Amazon") },
+            content = "Amazon",
             onClick = { return@SelectedActionItem true }
         )
     )

--- a/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/bottomnavigations/BottomNavigationColors.kt
+++ b/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/bottomnavigations/BottomNavigationColors.kt
@@ -5,7 +5,8 @@ import androidx.compose.ui.graphics.Color
 
 @Immutable
 class BottomNavigationColors(
-    val background: Color,
-    val selected: Color,
-    val unSelected: Color
+    val backgroundColor: Color,
+    val selectedIconColor: Color,
+    val selectedTextColor: Color,
+    val unselectedColor: Color
 )

--- a/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/bottomnavigations/VitaminBottomNavigationColors.kt
+++ b/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/bottomnavigations/VitaminBottomNavigationColors.kt
@@ -8,18 +8,21 @@ import com.decathlon.vitamin.compose.foundation.VitaminTheme
 object VitaminBottomNavigationColors {
     @Composable
     fun primary(
-        background: Color = VitaminTheme.colors.vtmnBackgroundPrimary,
-        selected: Color = VitaminTheme.colors.vtmnContentActive,
-        unSelected: Color = VitaminTheme.colors.vtmnContentTertiary,
+        backgroundColor: Color = VitaminTheme.colors.vtmnBackgroundPrimary,
+        selectedIconColor: Color = VitaminTheme.colors.vtmnContentActive,
+        selectedTextColor: Color = VitaminTheme.colors.vtmnContentPrimary,
+        unSelectedColor: Color = VitaminTheme.colors.vtmnContentTertiary
     ): BottomNavigationColors = remember(
-        background,
-        selected,
-        unSelected
+        backgroundColor,
+        selectedIconColor,
+        selectedTextColor,
+        unSelectedColor
     ) {
         BottomNavigationColors(
-            background = background,
-            selected = selected,
-            unSelected = unSelected
+            backgroundColor = backgroundColor,
+            selectedIconColor = selectedIconColor,
+            selectedTextColor = selectedTextColor,
+            unselectedColor = unSelectedColor,
         )
     }
 }

--- a/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/bottomnavigations/VitaminBottomNavigations.kt
+++ b/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/bottomnavigations/VitaminBottomNavigations.kt
@@ -3,15 +3,17 @@ package com.decathlon.vitamin.compose.appbars.bottomnavigations
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import com.decathlon.vitamin.compose.foundation.VitaminTheme
 
 open class SelectedActionItem(
     val selected: Boolean = false,
     val icon: Painter,
     val contentDescription: String?,
-    val content: @Composable () -> Unit = {},
+    val text: String,
     val onClick: () -> Boolean
 )
 
@@ -31,17 +33,22 @@ object VitaminBottomNavigations {
     ) {
         BottomNavigation(
             modifier = modifier,
-            backgroundColor = colors.background,
-            contentColor = colors.unSelected
+            backgroundColor = colors.backgroundColor
         ) {
             actions.forEach {
+                val textColor = if (it.selected) colors.selectedTextColor else colors.unselectedColor
+                val iconColor = if (it.selected) colors.selectedIconColor else colors.unselectedColor
                 BottomNavigationItem(
                     selected = it.selected,
                     onClick = { it.onClick() },
-                    icon = { Icon(painter = it.icon, contentDescription = it.contentDescription) },
-                    label = it.content,
-                    selectedContentColor = colors.selected,
-                    unselectedContentColor = colors.unSelected
+                    icon = {
+                        Icon(
+                            painter = it.icon,
+                            tint = iconColor,
+                            contentDescription = it.contentDescription
+                        )
+                    },
+                    label = { Text(text = it.text, color = textColor, style = VitaminTheme.typography.caption) }
                 )
             }
         }

--- a/sample/src/main/java/com/decathlon/compose/sample/screens/AppBars.kt
+++ b/sample/src/main/java/com/decathlon/compose/sample/screens/AppBars.kt
@@ -224,35 +224,48 @@ object AppBars : Screen {
                     )
                 }
                 item {
+                    val selectedId = remember { mutableStateOf("android") }
                     VitaminBottomNavigations.Primary(
                         actions = arrayListOf(
                             SelectedActionItem(
-                                selected = true,
+                                selected = selectedId.value == "android",
                                 icon = painterResource(R.drawable.ic_vtmn_android_line),
                                 contentDescription = null,
-                                content = { Text("Android") },
-                                onClick = { return@SelectedActionItem true }
+                                text = "Android",
+                                onClick = {
+                                    selectedId.value = "android"
+                                    return@SelectedActionItem true
+                                }
                             ),
                             SelectedActionItem(
-                                selected = false,
+                                selected = selectedId.value == "apple",
                                 icon = painterResource(R.drawable.ic_vtmn_apple_line),
                                 contentDescription = null,
-                                content = { Text("Apple") },
-                                onClick = { return@SelectedActionItem true }
+                                text = "Apple",
+                                onClick = {
+                                    selectedId.value = "apple"
+                                    return@SelectedActionItem true
+                                }
                             ),
                             SelectedActionItem(
-                                selected = false,
+                                selected = selectedId.value == "amazon",
                                 icon = painterResource(R.drawable.ic_vtmn_amazon_line),
                                 contentDescription = null,
-                                content = { Text("Amazon") },
-                                onClick = { return@SelectedActionItem true }
+                                text = "Amazon",
+                                onClick = {
+                                    selectedId.value = "amazon"
+                                    return@SelectedActionItem true
+                                }
                             ),
                             SelectedActionItem(
-                                selected = false,
+                                selected = selectedId.value == "facebook",
                                 icon = painterResource(R.drawable.ic_vtmn_facebook_line),
                                 contentDescription = null,
-                                content = { Text("Facebook") },
-                                onClick = { return@SelectedActionItem true }
+                                text = "Facebook",
+                                onClick = {
+                                    selectedId.value = "facebook"
+                                    return@SelectedActionItem true
+                                }
                             )
                         )
                     )


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
Fix for the selected color state of the label in the bottom navigation bar

## Context 🤔
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
[#33](https://github.com/Decathlon/vitamin-compose/issues/33)

## Checklist ✅
<!--- Feel free to add other steps if needed -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check compose contract convention. It must follow conventions described [here](/CONVENTIONS.md).
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [x] I have tested on a tablet device/emulator.
- [x] I have tested on a large screen device/emulator.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Screenshots 📸
<!--- Put your phone screenshots here -->
![Screenshot_20220812_170327](https://user-images.githubusercontent.com/48826368/184383792-2608925b-1ecd-43e8-a447-3deea808da70.png)

## Other info 👋
<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->
