### PR TITLE
fix(Dropdown): Add click on textInput

### DIFF
--- a/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/OverflowMenu.kt
+++ b/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/OverflowMenu.kt
@@ -1,5 +1,6 @@
 package com.decathlon.vitamin.compose.appbars
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -14,12 +15,14 @@ internal fun OverflowMenu(
     actions: List<ActionItem>,
     modifier: Modifier = Modifier,
     expanded: MutableState<Boolean> = remember { mutableStateOf(false) },
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     onDismissRequest: (() -> Unit)? = null,
     overflowIcon: @Composable VitaminMenuIconButtons.() -> Unit
 ) {
     VitaminMenus.Dropdown(
         expanded = expanded,
         modifier = modifier,
+        interactionSource = interactionSource,
         onDismissRequest = {
             onDismissRequest?.let { it() }
         },

--- a/menus/README.md
+++ b/menus/README.md
@@ -22,6 +22,7 @@ object VitaminMenus {
         anchor: @Composable () -> Unit,
         modifier: Modifier = Modifier,
         expanded: MutableState<Boolean> = remember { mutableStateOf(false) },
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
         onDismissRequest: () -> Unit = {},
         children: @Composable VitaminMenuItems.() -> Unit
     )
@@ -59,6 +60,7 @@ Parameters | Descriptions
 `anchor: @Composable () -> Unit` | Component where the dropdown menu is attached
 `modifier: Modifier = Modifier` | The `Modifier` to be applied to the component
 `expanded: MutableState<Boolean> = remember { mutableStateOf(false) }` | State to open or close the dropdown menu
+`interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | Representing the stream of interaction for the text input
 `onDismissRequest: () -> Unit = {}` | The callback to be called when the dropdown menu is dismiss
 `children: @Composable VitaminMenuItems.() -> Unit` | Declare your dropdown menu item components inside your dropdown
 

--- a/menus/src/main/java/com/decathlon/vitamin/compose/dropdown/VitaminMenus.kt
+++ b/menus/src/main/java/com/decathlon/vitamin/compose/dropdown/VitaminMenus.kt
@@ -1,12 +1,16 @@
 package com.decathlon.vitamin.compose.dropdown
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material.DropdownMenu
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.flow.filter
 
 object VitaminMenus {
     /**
@@ -22,9 +26,18 @@ object VitaminMenus {
         anchor: @Composable () -> Unit,
         modifier: Modifier = Modifier,
         expanded: MutableState<Boolean> = remember { mutableStateOf(false) },
+        interactionSource: MutableInteractionSource,
         onDismissRequest: () -> Unit = {},
         children: @Composable VitaminMenuItems.() -> Unit
     ) {
+        LaunchedEffect(interactionSource) {
+            interactionSource.interactions
+                .filter { it is PressInteraction.Press }
+                .collect {
+                    expanded.value = !expanded.value
+                }
+        }
+
         Box {
             anchor()
             DropdownMenu(

--- a/menus/src/main/java/com/decathlon/vitamin/compose/dropdown/VitaminMenus.kt
+++ b/menus/src/main/java/com/decathlon/vitamin/compose/dropdown/VitaminMenus.kt
@@ -18,6 +18,7 @@ object VitaminMenus {
      * @param anchor Component where the dropdown menu is attached
      * @param modifier The [Modifier] to be applied to this BottomNavigation
      * @param expanded State to open or close the dropdown menu
+     * @param interactionSource Representing the stream of interaction for the text input
      * @param onDismissRequest The callback to be called when the dropdown menu is dismiss
      * @param children Declare your dropdown menu item components inside your dropdown
      */
@@ -26,7 +27,7 @@ object VitaminMenus {
         anchor: @Composable () -> Unit,
         modifier: Modifier = Modifier,
         expanded: MutableState<Boolean> = remember { mutableStateOf(false) },
-        interactionSource: MutableInteractionSource,
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
         onDismissRequest: () -> Unit = {},
         children: @Composable VitaminMenuItems.() -> Unit
     ) {

--- a/text-inputs/README.md
+++ b/text-inputs/README.md
@@ -137,6 +137,7 @@ Parameters | Descriptions
 `modifier: Modifier = Modifier` | The `Modifier` to be applied to the component
 `enabled: Boolean = true` | True if you can type in the text input, otherwise false
 `expanded: MutableState<Boolean> = remember { mutableStateOf(false) }` | State to open or close the dropdown menu
+`interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | Representing the stream of interaction for the text input
 `colors: TextInputStateColors = TextInputsState.normal()` | The color to notify your user if they are in normal, error or success state
 `textStyle: TextStyle = VitaminTheme.typography.body2` | The typography of the text inside the text input
 `children: @Composable VitaminMenuItems.() -> Unit` | Declare your dropdown menu item components inside your dropdown
@@ -265,6 +266,7 @@ Parameters | Descriptions
 `modifier: Modifier = Modifier` | The `Modifier` to be applied to the component
 `enabled: Boolean = true` | True if you can type in the text input, otherwise false
 `expanded: MutableState<Boolean> = remember { mutableStateOf(false) }` | State to open or close the dropdown menu
+`interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }` | Representing the stream of interaction for the text input
 `colors: TextInputStateColors = TextInputsState.normal()` | The color to notify your user if they are in normal, error or success state
 `textStyle: TextStyle = VitaminTheme.typography.body2` | The typography of the text inside the text input
 `children: @Composable VitaminMenuItems.() -> Unit` | Declare your dropdown menu item components inside your dropdown

--- a/text-inputs/src/main/java/com/decathlon/vitamin/compose/textinputs/VitaminTextInputs.kt
+++ b/text-inputs/src/main/java/com/decathlon/vitamin/compose/textinputs/VitaminTextInputs.kt
@@ -1,6 +1,7 @@
 package com.decathlon.vitamin.compose.textinputs
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,6 +18,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,6 +38,7 @@ import androidx.compose.ui.unit.toSize
 import com.decathlon.vitamin.compose.dropdown.VitaminMenuItems
 import com.decathlon.vitamin.compose.dropdown.VitaminMenus.Dropdown
 import com.decathlon.vitamin.compose.foundation.VitaminTheme
+import kotlinx.coroutines.flow.filter
 
 object VitaminTextInputs {
     /**
@@ -167,10 +170,12 @@ object VitaminTextInputs {
         modifier: Modifier = Modifier,
         enabled: Boolean = true,
         expanded: MutableState<Boolean> = remember { mutableStateOf(false) },
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
         colors: TextInputStateColors = TextInputsState.normal(),
         textStyle: TextStyle = VitaminTheme.typography.text2,
         children: @Composable VitaminMenuItems.() -> Unit
     ) {
+
         var mTextFieldSize by remember { mutableStateOf(Size.Zero) }
         Dropdown(
             expanded = expanded,
@@ -187,6 +192,7 @@ object VitaminTextInputs {
                     singleLine = true,
                     maxLines = 1,
                     enabled = enabled,
+                    interactionSource = interactionSource,
                     onValueChange = {},
                     icon = {
                         IconButton(onClick = { expanded.value = true }) {
@@ -199,7 +205,8 @@ object VitaminTextInputs {
                 )
             },
             modifier = modifier.width(with(LocalDensity.current) { mTextFieldSize.width.toDp() }),
-            children = children
+            children = children,
+            interactionSource = interactionSource
         )
     }
 
@@ -332,6 +339,7 @@ object VitaminTextInputs {
         modifier: Modifier = Modifier,
         enabled: Boolean = true,
         expanded: MutableState<Boolean> = remember { mutableStateOf(false) },
+        interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
         colors: TextInputStateColors = TextInputsState.normal(),
         textStyle: TextStyle = VitaminTheme.typography.text2,
         children: @Composable VitaminMenuItems.() -> Unit
@@ -353,6 +361,7 @@ object VitaminTextInputs {
                     maxLines = 1,
                     enabled = enabled,
                     onValueChange = {},
+                    interactionSource = interactionSource,
                     icon = {
                         IconButton(onClick = { expanded.value = true }) {
                             Icon(
@@ -360,11 +369,12 @@ object VitaminTextInputs {
                                 contentDescription = stringResource(id = R.string.vtmn_text_inputs_open_menu)
                             )
                         }
-                    }
+                    },
                 )
             },
             modifier = modifier.width(with(LocalDensity.current) { mTextFieldSize.width.toDp() }),
-            children = children
+            children = children,
+            interactionSource = interactionSource
         )
     }
 }

--- a/text-inputs/src/main/java/com/decathlon/vitamin/compose/textinputs/VitaminTextInputs.kt
+++ b/text-inputs/src/main/java/com/decathlon/vitamin/compose/textinputs/VitaminTextInputs.kt
@@ -1,7 +1,6 @@
 package com.decathlon.vitamin.compose.textinputs
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,7 +17,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,7 +36,6 @@ import androidx.compose.ui.unit.toSize
 import com.decathlon.vitamin.compose.dropdown.VitaminMenuItems
 import com.decathlon.vitamin.compose.dropdown.VitaminMenus.Dropdown
 import com.decathlon.vitamin.compose.foundation.VitaminTheme
-import kotlinx.coroutines.flow.filter
 
 object VitaminTextInputs {
     /**
@@ -159,6 +156,7 @@ object VitaminTextInputs {
      * @param modifier The `Modifier` to be applied to the component
      * @param enabled True if you can type in the text input, otherwise false
      * @param expanded State to open or close the dropdown menu
+     * @param interactionSource Representing the stream of interaction for the text input
      * @param colors The color to notify your user if they are in normal, error or success state
      * @param textStyle The typography of the text inside the text input
      * @param children Declare your dropdown menu item components inside your dropdown
@@ -175,7 +173,6 @@ object VitaminTextInputs {
         textStyle: TextStyle = VitaminTheme.typography.text2,
         children: @Composable VitaminMenuItems.() -> Unit
     ) {
-
         var mTextFieldSize by remember { mutableStateOf(Size.Zero) }
         Dropdown(
             expanded = expanded,
@@ -328,6 +325,7 @@ object VitaminTextInputs {
      * @param modifier The `Modifier` to be applied to the component
      * @param enabled True if you can type in the text input, otherwise false
      * @param expanded State to open or close the dropdown menu
+     * @param interactionSource Representing the stream of interaction for the text input
      * @param colors The color to notify your user if they are in normal, error or success state
      * @param textStyle The typography of the text inside the text input
      * @param children Declare your dropdown menu item components inside your dropdown


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
Currently, the clic on the dropdown's texfield is not set.
I added an interactionSource to do so 

## Context 🤔
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Checklist ✅
<!--- Feel free to add other steps if needed -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check compose contract convention. It must follow conventions described [here](/CONVENTIONS.md).
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- [ ] I have tested on a tablet device/emulator.
- [ ] I have tested on a large screen device/emulator.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Screenshots 📸
<!--- Put your phone screenshots here -->

## Other info 👋
<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->
