### PR TITLE
feat(tabs): manage tabItems size

### DIFF
--- a/tabs/README.md
+++ b/tabs/README.md
@@ -34,6 +34,8 @@ The fixed tabs displays all tabs in a set simultaneously.
 The minimal usage of the component is the list of tab items with a label and optionally an icon.
 You can configure all tabs content if you want something more complex.
 
+This component need to have at least 2 tabItems. Otherwise an [IllegalArgumentException] will be thrown.
+
 ```kotlin
 val icon = painterResource(id = R.drawable.ic_vtmn_heart_3_line)
 val list = remember {
@@ -77,6 +79,8 @@ text labels and a larger number of tabs. They are best used for browsing on touc
 
 The minimal usage of the component is the list of tab items with a label and optionally an icon.
 You can configure all tabs content if you want something more complex.
+
+This component need to have at least 2 tabItems. Otherwise an [IllegalArgumentException] will be thrown.
 
 ```kotlin
 val icon = painterResource(id = R.drawable.ic_vtmn_heart_3_line)

--- a/tabs/src/main/java/com/decathlon/vitamin/compose/tabs/VitaminTabs.kt
+++ b/tabs/src/main/java/com/decathlon/vitamin/compose/tabs/VitaminTabs.kt
@@ -20,6 +20,8 @@ object VitaminTabs {
      * @param textStyle The text style of the label inside tabs
      * @param textOverflow How visual overflow should be handled
      * @param onTabClicked The callback to be called when the user click on a tab
+     *
+     * @throws IllegalArgumentException if tabItems not have at least 2 items
      */
     @Composable
     fun Fixed(
@@ -30,8 +32,10 @@ object VitaminTabs {
         textOverflow: TextOverflow = TextOverflow.Ellipsis,
         onTabClicked: (tabItem: TabItem) -> Unit
     ) {
+        validateTabItems(tabItems)
         val selectedTab = tabItems.firstOrNull { it.selected } ?: tabItems.first()
         val indexOfSelectedTab = tabItems.indexOf(selectedTab)
+
         TabRow(
             selectedTabIndex = indexOfSelectedTab,
             backgroundColor = colors.backgroundColor,
@@ -64,6 +68,8 @@ object VitaminTabs {
      * @param textStyle The text style of the label inside tabs
      * @param textOverflow How visual overflow should be handled
      * @param onTabClicked The callback to be called when the user click on a tab
+     *
+     * @throws IllegalArgumentException if tabItems not have at least 2 items
      */
     @Composable
     fun Scrollable(
@@ -74,6 +80,7 @@ object VitaminTabs {
         textOverflow: TextOverflow = TextOverflow.Ellipsis,
         onTabClicked: (tabItem: TabItem) -> Unit
     ) {
+        validateTabItems(tabItems)
         val selectedTab = tabItems.firstOrNull { it.selected } ?: tabItems.first()
         val indexOfSelectedTab = tabItems.indexOf(selectedTab)
 
@@ -106,4 +113,10 @@ object VitaminTabs {
 
     private fun getTabHeight(list: List<TabItem>) =
         if (list.any { it.topIcon }) 72.dp else 48.dp
+
+    private fun validateTabItems(tabItems: List<TabItem>) {
+        if (tabItems.size < 2) {
+            throw IllegalArgumentException("tabItems must have at least 2 items")
+        }
+    }
 }


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
- throw IllegalArgumentException when `tabItems` contains less than 2 items.

## Context 🤔
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Closes #72 

## Checklist ✅
<!--- Feel free to add other steps if needed -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check compose contract convention. It must follow conventions described [here](/CONVENTIONS.md).
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- I have tested on a tablet device/emulator.
- I have tested on a large screen device/emulator.
- If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Other info 👋
<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->
```bash
    java.lang.IllegalArgumentException: tabItems must have at least 2 items
        at com.decathlon.vitamin.compose.tabs.VitaminTabs.validateTabItems(VitaminTabs.kt:119)
        at com.decathlon.vitamin.compose.tabs.VitaminTabs.Fixed-kKmfEb0(VitaminTabs.kt:35)
```
