### PR TITLE
chore: add github action for pull requests

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,44 @@
+name: Build Pull Request
+
+on:
+  pull_request: {}
+
+jobs:
+  build:
+    permissions: write-all
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+          
+      - uses: juztcode/pr-updater@1.0.0
+        if: ${{ github.head_ref == 'feat/update-icons' }}
+        with:
+          title: 'feat: update icons'
+          body: '**Automated Pull Request to update icons.**'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: danielswensson/auto-assign-owner-action@v1
+        if: ${{ github.head_ref == 'feat/update-icons' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ github.head_ref == 'feat/update-icons' }}
+        with:
+          labels: |
+            enhancement 🚀
+            icons ✨
+            run 💨
+          
+      - uses: actions/add-to-project@v0.4.0
+        if: ${{ github.head_ref == 'feat/update-icons' }}
+        with:
+          project-url: https://github.com/orgs/Decathlon/projects/3
+          github-token: ${{ secrets.API_TOKEN_GITHUB }}


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Hello,
I propose to add this GitHub action which automate some behaviors when a new automated PR for update icons arrives:
- Change title of the PR
- Change body of the PR
- Add labels to the PR
- Auto-assign owner of the PR
- Add to GitHub projects board

Thanks!