### PR TITLE
feat(buttons): add button loading state

### DIFF
--- a/buttons/src/main/java/com/decathlon/vitamin/compose/buttons/VitaminButtonLoader.kt
+++ b/buttons/src/main/java/com/decathlon/vitamin/compose/buttons/VitaminButtonLoader.kt
@@ -1,0 +1,100 @@
+package com.decathlon.vitamin.compose.buttons
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RowScope.VitaminButtonLoader(color: Color) {
+    Row(
+        modifier = Modifier
+            .weight(1f)
+            .height(21.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val infiniteTransition = rememberInfiniteTransition()
+        val duration = 1000
+        val durationRatio = duration / 4
+        val animations = (0..2).map { index ->
+            val alpha by infiniteTransition.animateFloat(
+                initialValue = when (index) {
+                    0 -> 1.0f
+                    1 -> 0.5f
+                    else -> 0.2f
+                },
+                targetValue = when (index) {
+                    0 -> 1.0f
+                    1 -> 0.5f
+                    else -> 0.2f
+                },
+                animationSpec = infiniteRepeatable(
+                    animation = keyframes {
+                        durationMillis = duration
+                        when (index) {
+                            0 -> {
+                                1.0f at 0
+                                0.5f at 1 * durationRatio
+                                0.2f at 2 * durationRatio
+                                0.5f at 3 * durationRatio
+                                1.0f at 4 * durationRatio
+                            }
+                            1 -> {
+                                0.5f at 0
+                                0.2f at 1 * durationRatio
+                                0.5f at 2 * durationRatio
+                                1.0f at 3 * durationRatio
+                                0.5f at 4 * durationRatio
+                            }
+                            else -> {
+                                0.2f at 0
+                                0.5f at 1 * durationRatio
+                                1.0f at 2 * durationRatio
+                                0.5f at 3 * durationRatio
+                                0.2f at 4 * durationRatio
+                            }
+                        }
+                    },
+                    repeatMode = RepeatMode.Reverse
+                )
+            )
+            alpha
+        }
+
+        Box(
+            Modifier
+                .size(8.dp)
+                .graphicsLayer(alpha = animations[0])
+                .background(color, CircleShape)
+        )
+        Box(
+            Modifier
+                .size(8.dp)
+                .graphicsLayer(alpha = animations[1])
+                .background(color, CircleShape)
+        )
+        Box(
+            Modifier
+                .size(8.dp)
+                .graphicsLayer(alpha = animations[2])
+                .background(color, CircleShape)
+        )
+    }
+}

--- a/buttons/src/main/java/com/decathlon/vitamin/compose/buttons/VitaminButtons.kt
+++ b/buttons/src/main/java/com/decathlon/vitamin/compose/buttons/VitaminButtons.kt
@@ -1,5 +1,9 @@
 package com.decathlon.vitamin.compose.buttons
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
@@ -15,7 +19,9 @@ import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,6 +37,7 @@ object VitaminButtons {
      * @param icon The optional icon to be displayed at the start or the end of the button container
      * @param iconSide If an icon is added, you can configure the side at the start or end of the button
      * @param enabled True if you can click on the button, otherwise false
+     * @param loading True if the button display a loader and disable the onClick callback, otherwise false
      * @param colors The colors of the background and the content in enabled and disabled
      * @param sizes The sizes for the text, paddings and width/height
      * @param borders The width and color of the border in enabled and disabled
@@ -44,6 +51,7 @@ object VitaminButtons {
         icon: Painter? = null,
         iconSide: IconSide = IconSide.LEFT,
         enabled: Boolean = true,
+        loading: Boolean = false,
         colors: ButtonColors = VitaminButtonsColors.primary(),
         sizes: ButtonSizes = VitaminButtonsSizes.medium(),
         borders: ButtonBorders = VitaminButtonBorders.none(),
@@ -55,6 +63,7 @@ object VitaminButtons {
         icon = icon,
         iconSide = iconSide,
         enabled = enabled,
+        loading = loading,
         colors = colors,
         sizes = sizes,
         borders = borders,
@@ -69,6 +78,7 @@ object VitaminButtons {
      * @param icon The optional icon to be displayed at the start or the end of the button container
      * @param iconSide If an icon is added, you can configure the side at the start or end of the button
      * @param enabled True if you can click on the button, otherwise false
+     * @param loading True if the button display a loader and disable the onClick callback, otherwise false
      * @param colors The colors of the background and the content in enabled and disabled
      * @param sizes The sizes for the text, paddings and width/height
      * @param borders The width and color of the border in enabled and disabled
@@ -82,6 +92,7 @@ object VitaminButtons {
         icon: Painter? = null,
         iconSide: IconSide = IconSide.LEFT,
         enabled: Boolean = true,
+        loading: Boolean = false,
         colors: ButtonColors = VitaminButtonsColors.primaryReversed(),
         sizes: ButtonSizes = VitaminButtonsSizes.medium(),
         borders: ButtonBorders = VitaminButtonBorders.none(),
@@ -93,6 +104,7 @@ object VitaminButtons {
         icon = icon,
         iconSide = iconSide,
         enabled = enabled,
+        loading = loading,
         colors = colors,
         sizes = sizes,
         borders = borders,
@@ -108,6 +120,7 @@ object VitaminButtons {
      * @param icon The optional icon to be displayed at the start or the end of the button container
      * @param iconSide If an icon is added, you can configure the side at the start or end of the button
      * @param enabled True if you can click on the button, otherwise false
+     * @param loading True if the button display a loader and disable the onClick callback, otherwise false
      * @param colors The colors of the background and the content in enabled and disabled
      * @param sizes The sizes for the text, paddings and width/height
      * @param borders The width and color of the border in enabled and disabled
@@ -121,6 +134,7 @@ object VitaminButtons {
         icon: Painter? = null,
         iconSide: IconSide = IconSide.LEFT,
         enabled: Boolean = true,
+        loading: Boolean = false,
         colors: ButtonColors = VitaminButtonsColors.secondary(),
         sizes: ButtonSizes = VitaminButtonsSizes.medium(),
         borders: ButtonBorders = VitaminButtonBorders.primary(),
@@ -132,6 +146,7 @@ object VitaminButtons {
         icon = icon,
         iconSide = iconSide,
         enabled = enabled,
+        loading = loading,
         colors = colors,
         sizes = sizes,
         borders = borders,
@@ -147,6 +162,7 @@ object VitaminButtons {
      * @param icon The optional icon to be displayed at the start or the end of the button container
      * @param iconSide If an icon is added, you can configure the side at the start or end of the button
      * @param enabled True if you can click on the button, otherwise false
+     * @param loading True if the button display a loader and disable the onClick callback, otherwise false
      * @param colors The colors of the background and the content in enabled and disabled
      * @param sizes The sizes for the text, paddings and width/height
      * @param borders The width and color of the border in enabled and disabled
@@ -160,6 +176,7 @@ object VitaminButtons {
         icon: Painter? = null,
         iconSide: IconSide = IconSide.LEFT,
         enabled: Boolean = true,
+        loading: Boolean = false,
         colors: ButtonColors = VitaminButtonsColors.tertiary(),
         sizes: ButtonSizes = VitaminButtonsSizes.medium(),
         borders: ButtonBorders = VitaminButtonBorders.none(),
@@ -171,6 +188,7 @@ object VitaminButtons {
         icon = icon,
         iconSide = iconSide,
         enabled = enabled,
+        loading = loading,
         colors = colors,
         sizes = sizes,
         borders = borders,
@@ -187,6 +205,7 @@ object VitaminButtons {
      * @param icon The optional icon to be displayed at the start or the end of the button container
      * @param iconSide If an icon is added, you can configure the side at the start or end of the button
      * @param enabled True if you can click on the button, otherwise false
+     * @param loading True if the button display a loader and disable the onClick callback, otherwise false
      * @param colors The colors of the background and the content in enabled and disabled
      * @param sizes The sizes for the text, paddings and width/height
      * @param borders The width and color of the border in enabled and disabled
@@ -200,6 +219,7 @@ object VitaminButtons {
         icon: Painter? = null,
         iconSide: IconSide = IconSide.LEFT,
         enabled: Boolean = true,
+        loading: Boolean = false,
         colors: ButtonColors = VitaminButtonsColors.ghost(),
         sizes: ButtonSizes = VitaminButtonsSizes.medium(),
         borders: ButtonBorders = VitaminButtonBorders.none(),
@@ -211,6 +231,7 @@ object VitaminButtons {
         icon = icon,
         iconSide = iconSide,
         enabled = enabled,
+        loading = loading,
         colors = colors,
         sizes = sizes,
         borders = borders,
@@ -226,6 +247,7 @@ object VitaminButtons {
      * @param icon The optional icon to be displayed at the start or the end of the button container
      * @param iconSide If an icon is added, you can configure the side at the start or end of the button
      * @param enabled True if you can click on the button, otherwise false
+     * @param loading True if the button display a loader and disable the onClick callback, otherwise false
      * @param colors The colors of the background and the content in enabled and disabled
      * @param sizes The sizes for the text, paddings and width/height
      * @param borders The width and color of the border in enabled and disabled
@@ -239,6 +261,7 @@ object VitaminButtons {
         icon: Painter? = null,
         iconSide: IconSide = IconSide.LEFT,
         enabled: Boolean = true,
+        loading: Boolean = false,
         colors: ButtonColors = VitaminButtonsColors.ghostReversed(),
         sizes: ButtonSizes = VitaminButtonsSizes.medium(),
         borders: ButtonBorders = VitaminButtonBorders.none(),
@@ -250,6 +273,7 @@ object VitaminButtons {
         icon = icon,
         iconSide = iconSide,
         enabled = enabled,
+        loading = loading,
         colors = colors,
         sizes = sizes,
         borders = borders,
@@ -265,6 +289,7 @@ object VitaminButtons {
      * @param icon The optional icon to be displayed at the start or the end of the button container
      * @param iconSide If an icon is added, you can configure the side at the start or end of the button
      * @param enabled True if you can click on the button, otherwise false
+     * @param loading True if the button display a loader and disable the onClick callback, otherwise false
      * @param colors The colors of the background and the content in enabled and disabled
      * @param sizes The sizes for the text, paddings and width/height
      * @param borders The width and color of the border in enabled and disabled
@@ -278,6 +303,7 @@ object VitaminButtons {
         icon: Painter? = null,
         iconSide: IconSide = IconSide.LEFT,
         enabled: Boolean = true,
+        loading: Boolean = false,
         colors: ButtonColors = VitaminButtonsColors.conversion(),
         sizes: ButtonSizes = VitaminButtonsSizes.medium(),
         borders: ButtonBorders = VitaminButtonBorders.none(),
@@ -289,6 +315,7 @@ object VitaminButtons {
         icon = icon,
         iconSide = iconSide,
         enabled = enabled,
+        loading = loading,
         colors = colors,
         sizes = sizes,
         borders = borders,
@@ -303,13 +330,14 @@ private val ButtonIconPadding = 8.dp
 
 @Composable
 internal fun VitaminButtonImpl(
+    modifier: Modifier = Modifier,
     text: String,
     enabled: Boolean,
+    loading: Boolean,
     colors: ButtonColors,
     sizes: ButtonSizes,
     ripple: RippleTheme,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
     icon: Painter? = null,
     iconSide: IconSide? = null,
     borders: ButtonBorders = VitaminButtonBorders.none(),
@@ -342,17 +370,46 @@ internal fun VitaminButtonImpl(
             border = if (enabled) borders.stroke else borders.disabled,
             contentPadding = sizes.contentPadding,
             elevation = elevation,
-            onClick = onClick
+            onClick = { if (!loading) onClick.invoke() }
         ) {
-            if (iconSide == IconSide.LEFT) iconButton()
-            Text(
-                modifier = Modifier.weight(1f, fill = false),
+            ButtonContent(
                 text = text,
-                style = sizes.textStyle,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1
-            )
-            if (iconSide == IconSide.RIGHT) iconButton()
+                loading = loading,
+                sizes = sizes,
+                contentColor = colors.contentColor(enabled = enabled).value,
+                iconSide= iconSide,
+                iconButton = iconButton)
+        }
+    }
+}
+
+@Composable
+private fun RowScope.ButtonContent(
+    text: String,
+    loading: Boolean = false,
+    sizes: ButtonSizes,
+    contentColor: Color,
+    iconSide: IconSide? = null,
+    iconButton: @Composable () -> Unit?
+) {
+    Crossfade(targetState = loading, label = "cross fade") { loadingState ->
+        when {
+            loadingState -> VitaminButtonLoader(contentColor)
+            else -> Row(
+                Modifier.weight(1f),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally)
+            ) {
+                if (iconSide == IconSide.LEFT) iconButton()
+                Text(
+                    modifier = Modifier.weight(1f, fill = false),
+                    text = text,
+                    style = sizes.textStyle,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1
+                )
+                if (iconSide == IconSide.RIGHT) iconButton()
+            }
         }
     }
 }
@@ -367,9 +424,25 @@ private fun VitaminButtonPreview() {
 
 @Preview
 @Composable
+private fun VitaminButtonLoadingPreview() {
+    VitaminTheme {
+        VitaminButtons.Primary(text = "Gift selection", loading = true) {}
+    }
+}
+
+@Preview
+@Composable
 private fun VitaminPrimaryReversedButtonPreview() {
     VitaminTheme {
         VitaminButtons.PrimaryReversed(text = "Gift selection") {}
+    }
+}
+
+@Preview
+@Composable
+private fun VitaminPrimaryReversedButtonLoadingPreview() {
+    VitaminTheme {
+        VitaminButtons.PrimaryReversed(text = "Gift selection", loading = true) {}
     }
 }
 
@@ -383,9 +456,25 @@ private fun VitaminSecondaryButtonPreview() {
 
 @Preview
 @Composable
+private fun VitaminSecondaryButtonLoadingPreview() {
+    VitaminTheme {
+        VitaminButtons.Secondary(text = "Gift selection", loading = true) {}
+    }
+}
+
+@Preview
+@Composable
 private fun VitaminTertiaryButtonPreview() {
     VitaminTheme {
         VitaminButtons.Tertiary(text = "Gift selection") {}
+    }
+}
+
+@Preview
+@Composable
+private fun VitaminTertiaryButtonLoadingPreview() {
+    VitaminTheme {
+        VitaminButtons.Tertiary(text = "Gift selection", loading = true) {}
     }
 }
 
@@ -399,6 +488,14 @@ private fun VitaminGhostButtonPreview() {
 
 @Preview
 @Composable
+private fun VitaminGhostButtonLoadingPreview() {
+    VitaminTheme {
+        VitaminButtons.Ghost(text = "Gift selection", loading = true) {}
+    }
+}
+
+@Preview
+@Composable
 private fun VitaminGhostReversedButtonPreview() {
     VitaminTheme {
         VitaminButtons.GhostReversed(text = "Gift selection") {}
@@ -407,8 +504,24 @@ private fun VitaminGhostReversedButtonPreview() {
 
 @Preview
 @Composable
+private fun VitaminGhostReversedButtonLoadingPreview() {
+    VitaminTheme {
+        VitaminButtons.GhostReversed(text = "Gift selection", loading = true) {}
+    }
+}
+
+@Preview
+@Composable
 private fun VitaminConversionButtonPreview() {
     VitaminTheme {
         VitaminButtons.Conversion(text = "Gift selection") {}
+    }
+}
+
+@Preview
+@Composable
+private fun VitaminConversionButtonLoadingPreview() {
+    VitaminTheme {
+        VitaminButtons.Conversion(text = "Gift selection", loading = true) {}
     }
 }


### PR DESCRIPTION
## Changes description 🧑‍💻
VitaminButton components : add an animated loading state with a new parameter "loading: Boolean"

## Context 🤔
Very usefull when the click button run a long task, the button display a loader and disable the click

## Checklist ✅
<!--- Feel free to add other steps if needed -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check compose contract convention. It must follow conventions described [here](/CONVENTIONS.md).
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] I have tested on a tablet device/emulator.
- [ ] I have tested on a large screen device/emulator.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Screenshots 📸
<img width="694" alt="image" src="https://user-images.githubusercontent.com/58910280/223723672-3b20df15-ac97-4588-8c05-b51d05e1385e.png">
