### PR TITLE
fix: VitaminTopBars.Search crash

### DIFF
--- a/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/topbars/VitaminTopBars.kt
+++ b/appbars/src/main/java/com/decathlon/vitamin/compose/appbars/topbars/VitaminTopBars.kt
@@ -152,24 +152,26 @@ object VitaminTopBars {
                     keyboardActions = keyboardActions,
                     cursorBrush = SolidColor(colors.cursorColor!!),
                     decorationBox = { textField ->
-                        if (value == "") {
-                            Text(text = placeholder)
-                        } else {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxHeight()
-                                        .weight(1f),
-                                    contentAlignment = Alignment.CenterStart,
-                                ) {
-                                    textField()
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxHeight()
+                                    .weight(1f),
+                                contentAlignment = Alignment.CenterStart,
+                            ) {
+                                if (value.isEmpty()) {
+                                    Text(text = placeholder)
                                 }
+                                textField()
+                            }
+                            if (value.isNotEmpty()) {
                                 actions.forEach {
                                     when (it) {
                                         is SearchActionItem.Microphone -> VitaminSearchMenuIconButtons.Microphone(
                                             onClick = it.onClick,
                                             contentDescription = it.contentDescription
                                         )
+
                                         is SearchActionItem.Close -> VitaminSearchMenuIconButtons.Close(
                                             onClick = it.onClick,
                                             contentDescription = it.contentDescription


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
Call decorationBox innerTextField each time only

## Context 🤔
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Closes https://github.com/Decathlon/vitamin-compose/issues/146
## Checklist ✅
<!--- Feel free to add other steps if needed -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check compose contract convention. It must follow conventions described [here](/CONVENTIONS.md).
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [ ] I have tested on a phone device/emulator.
- [ ] I have tested on a tablet device/emulator.
- [ ] I have tested on a large screen device/emulator.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Screenshots 📸
<!--- Put your phone screenshots here -->

## Other info 👋
<!--- Feel free to add another major info here if needed -->
<!--- You can also remove this section -->
