### PR TITLE
fix(ratings): Fix number of stars shown in VitaminRatings composables

### DIFF
--- a/ratings/src/main/java/com/decathlon/vitamin/compose/ratings/Icon.kt
+++ b/ratings/src/main/java/com/decathlon/vitamin/compose/ratings/Icon.kt
@@ -15,16 +15,22 @@ internal sealed class Icon(val imageVector: ImageVector) {
     object Fill : Icon(imageVector = VitaminIcons.Fill.Star)
 
     companion object {
-        private const val HALF = 0.5f
+        private const val EMPTY_LOWER_BOUND = 0f
+        private const val EMPTY_UPPER_BOUND = 0.24f
+        private const val HALF_LOWER_BOUND = 0.25f
+        private const val HALF_UPPER_BOUND = 0.75f
+        private const val FILL_LOWER_BOUND = 0.76f
+        private const val FILL_UPPER_BOUND = 1f
+
         fun get(index: Int, number: Float): Icon {
             val floor = floor(number).toInt()
             val decimal = number - index
-            return if (floor == index && decimal != 0f) {
-                if (decimal < HALF) Half else Fill
-            } else if (index < number) {
-                Fill
-            } else {
-                Empty
+            return when {
+                index < floor -> Fill
+                decimal in EMPTY_LOWER_BOUND..EMPTY_UPPER_BOUND -> Empty
+                decimal in HALF_LOWER_BOUND..HALF_UPPER_BOUND -> Half
+                decimal in FILL_LOWER_BOUND..FILL_UPPER_BOUND -> Fill
+                else -> Empty
             }
         }
     }

--- a/ratings/src/test/kotlin/com/decathlon/vitamin/compose/ratings/IconTest.kt
+++ b/ratings/src/test/kotlin/com/decathlon/vitamin/compose/ratings/IconTest.kt
@@ -1,0 +1,72 @@
+package com.decathlon.vitamin.compose.ratings
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class IconTest {
+    @Test
+    fun integer() {
+        val number = 3.0f
+
+        assertEquals(Icon.Fill, Icon.get(0, number))
+        assertEquals(Icon.Fill, Icon.get(1, number))
+        assertEquals(Icon.Fill, Icon.get(2, number))
+        assertEquals(Icon.Empty, Icon.get(3, number))
+        assertEquals(Icon.Empty, Icon.get(4, number))
+    }
+
+    @Test
+    fun close_above_int() {
+        val number = 3.2f
+
+        assertEquals(Icon.Fill, Icon.get(0, number))
+        assertEquals(Icon.Fill, Icon.get(1, number))
+        assertEquals(Icon.Fill, Icon.get(2, number))
+        assertEquals(Icon.Empty, Icon.get(3, number))
+        assertEquals(Icon.Empty, Icon.get(4, number))
+    }
+
+    @Test
+    fun close_below_half() {
+        val number = 3.4f
+
+        assertEquals(Icon.Fill, Icon.get(0, number))
+        assertEquals(Icon.Fill, Icon.get(1, number))
+        assertEquals(Icon.Fill, Icon.get(2, number))
+        assertEquals(Icon.Half, Icon.get(3, number))
+        assertEquals(Icon.Empty, Icon.get(4, number))
+    }
+
+    @Test
+    fun strictly_half() {
+        val number = 3.5f
+
+        assertEquals(Icon.Fill, Icon.get(0, number))
+        assertEquals(Icon.Fill, Icon.get(1, number))
+        assertEquals(Icon.Fill, Icon.get(2, number))
+        assertEquals(Icon.Half, Icon.get(3, number))
+        assertEquals(Icon.Empty, Icon.get(4, number))
+    }
+
+    @Test
+    fun close_above_half() {
+        val number = 3.6f
+
+        assertEquals(Icon.Fill, Icon.get(0, number))
+        assertEquals(Icon.Fill, Icon.get(1, number))
+        assertEquals(Icon.Fill, Icon.get(2, number))
+        assertEquals(Icon.Half, Icon.get(3, number))
+        assertEquals(Icon.Empty, Icon.get(4, number))
+    }
+
+    @Test
+    fun close_below_int() {
+        val number = 3.8f
+
+        assertEquals(Icon.Fill, Icon.get(0, number))
+        assertEquals(Icon.Fill, Icon.get(1, number))
+        assertEquals(Icon.Fill, Icon.get(2, number))
+        assertEquals(Icon.Fill, Icon.get(3, number))
+        assertEquals(Icon.Empty, Icon.get(4, number))
+    }
+}


### PR DESCRIPTION
## Changes description 🧑‍💻

First I wrote some tests to be sure I'm fixing something.
Then I fixed the algorithm deciding if a star should be Empty, Half or Fill.

## Context 🤔

Closes #175

## Checklist ✅

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check compose contract convention. It must follow conventions described [here](/CONVENTIONS.md).
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on a phone device/emulator.
- I have tested on a tablet device/emulator.
- I have tested on a large screen device/emulator.
- If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Screenshots 📸
Fixed ratings of 3.0, 3.1, ..., 3.9, 4.0
![VitaminRatings](https://github.com/Decathlon/vitamin-compose/assets/883959/77eb596d-d145-40a5-907d-2e363616d355)

## Other info 👋

This fix completes [another merged fix](https://github.com/Decathlon/vitamin-compose/pull/156) about whole numbers.
